### PR TITLE
perf: optimize translate function

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -35,8 +35,10 @@ export function createInstance(options: ResolvedVueI18nOptions): VueI18nInstance
   }
 
   const findLocaleMessage = (locale: string, key: string) =>
-    key.split('.').reduce<LocaleMessageValue | undefined>((path, segment) =>
-      (path as LocaleMessageDictionary | undefined)?.[segment], messages.value[locale])
+    key.includes('.')
+      ? key.split('.').reduce<LocaleMessageValue | undefined>((path, segment) =>
+        (path as LocaleMessageDictionary | undefined)?.[segment], messages.value[locale])
+      : messages.value[locale]?.[key]
 
   watch(locale, loadMessages)
 
@@ -55,13 +57,12 @@ export function createInstance(options: ResolvedVueI18nOptions): VueI18nInstance
       if (typeof message !== 'string')
         return key
 
-      const values: { [key: string]: string | number } = {
-        ...params[0],
-        ...params[1],
-      }
+      if (!params.length && !message.includes('|') && !message.includes('{'))
+        return message
 
-      if (typeof params[0] === 'number')
-        Object.assign(values, { count: params[0], n: params[0] })
+      const values: { [key: string]: string | number } = typeof params[0] === 'number'
+        ? { count: params[0], n: params[0], ...params[1] }
+        : { ...params[0] }
 
       if (message.includes('|')) {
         const count = [values.count, values.n].find(x => typeof x === 'number') ?? 1

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -37,7 +37,7 @@ export function createInstance(options: ResolvedVueI18nOptions): VueI18nInstance
   const findLocaleMessage = (locale: string, key: string) =>
     key.includes('.')
       ? key.split('.').reduce<LocaleMessageValue | undefined>((path, segment) =>
-        (path as LocaleMessageDictionary | undefined)?.[segment], messages.value[locale])
+          (path as LocaleMessageDictionary | undefined)?.[segment], messages.value[locale])
       : messages.value[locale]?.[key]
 
   watch(locale, loadMessages)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,8 +4,6 @@ import { injectionKey } from './constants'
 import { createInstance } from './instance'
 import type { ResolvedVueI18nOptions, VueI18nOptions } from './types'
 
-type VueI18nPlugin = FunctionPlugin
-
 const LOCALE_KEY_RE = /(\w*)\.(ya?ml|json)$/
 
 function resolveMessages(input: VueI18nOptions['messages']) {
@@ -16,7 +14,7 @@ function resolveMessages(input: VueI18nOptions['messages']) {
   return output
 }
 
-export async function createI18n(options: VueI18nOptions): Promise<VueI18nPlugin> {
+export async function createI18n(options: VueI18nOptions): Promise<FunctionPlugin> {
   const resolvedOptions: ResolvedVueI18nOptions = {
     locale: options.locale ?? 'en',
     fallbackLocale: options.fallbackLocale ?? options.locale ?? 'en',

--- a/test/composable.test.ts
+++ b/test/composable.test.ts
@@ -79,6 +79,21 @@ describe('composable', () => {
   })
 
   describe('translation behaviors', () => {
+    it('nested key', async () => {
+      const wrapper = await render({
+        messages: {
+          en: {
+            greetings: {
+              welcome: 'Welcome!',
+            },
+          },
+        },
+        template: t => t('greetings.welcome'),
+      })
+
+      expect(wrapper.text()).toBe('Welcome!')
+    })
+
     it('named interpolation', async () => {
       const wrapper = await render({
         messages: {


### PR DESCRIPTION
## Summary
- Short-circuit `t()` for plain messages with no params, avoiding unnecessary object allocation, pluralization, and regex replacement
- Fast path for flat keys in `findLocaleMessage` (direct property lookup instead of `split('.').reduce()`)
- Simplify `values` construction in `t()` from double-spread + `Object.assign` to a single conditional expression
- Remove unnecessary `VueI18nPlugin` type alias, inline `FunctionPlugin` directly
- Add nested key test to reach 100% coverage

## Test plan
- [x] All 11 tests pass
- [x] 100% coverage across statements, branches, functions, and lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)